### PR TITLE
wait for the file to be fully written on disk

### DIFF
--- a/bin/file-watcher.js
+++ b/bin/file-watcher.js
@@ -4,6 +4,10 @@ const paths = JSON.parse(process.argv[2]);
 
 const watcher = chokidar.watch(paths, {
     ignoreInitial: true,
+    awaitWriteFinish: {
+        stabilityThreshold: 2000,
+        pollInterval: 100
+    }
 });
 
 watcher


### PR DESCRIPTION
The filewatcher won't be as fast, but it will be more accurate if we wait until the file is completely written to disk. 

In our case we monitor an FTP directory so the file can take a while to be written and we need to work on the fully created file.

Are there better solutions than this, not knowing the final size of the file?