### PR TITLE
Fix: output being truncated and watcher crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ tests/testDirectory
 yarn.lock
 .php-cs-fixer.cache
 node_modules
+.DS_Store

--- a/tests/WatchTest.php
+++ b/tests/WatchTest.php
@@ -32,7 +32,7 @@ it('can detect when files get created', function () {
 
             $this->i++;
 
-            return $this->i <= 7;
+            return $this->i <= 10;
         })
         ->start();
 
@@ -64,7 +64,7 @@ it('can detect when files get updated', function () {
 
             $this->i++;
 
-            return $this->i <= 7;
+            return $this->i <= 10;
         })
         ->start();
 
@@ -96,7 +96,7 @@ it('can detect when files get deleted', function () {
 
             $this->i++;
 
-            return $this->i <= 7;
+            return $this->i <= 10;
         })
         ->start();
 
@@ -127,7 +127,7 @@ it('can detect when a directory gets created', function () {
 
             $this->i++;
 
-            return $this->i <= 7;
+            return $this->i <= 10;
         })
         ->start();
 
@@ -159,7 +159,7 @@ it('can detect when a directory gets deleted', function () {
 
             $this->i++;
 
-            return $this->i <= 7;
+            return $this->i <= 10;
         })
         ->start();
 


### PR DESCRIPTION
Hello friends 👋!

TLDR : Fix Exception when too much files are updated at once.

## Context
I was using this library to watch a Laravel project. When I did a `composer update` in the watched directory the script crashed with the following error: **Undefined array key 1**  referring to [this line](https://github.com/spatie/file-system-watcher/blob/48ada9f48c2474823d6f8653f77612ef89f3f5f4/src/Watch.php#L169C1-L169C1)
Tried a few times and every time a batch of files is updated at once I get the same error again.

With the help of `ray()` to see what was happening, I found the culprit.
```php
            try {
                [$type, $path] = explode(' - ', $line, 2);
            } catch (\Exception $e) {
                ray($line);
                continue;
            }
```

Here is a screenshot cleary showing what's wrong
<img width="954" alt="Capture d’écran 2023-10-29 à 10 51 33" src="https://github.com/spatie/file-system-watcher/assets/1408020/928d2b43-da5a-480f-a089-1445f77c33c8">

## The fix: what did I changed?
1. $buffer accumulates the incremental output. 
2. strrpos() function locates the last occurrence of PHP_EOL. 
3. If found, it indicates that at least one complete line exists in the $buffer. 
4. We then extract this complete lines and update the $buffer accordingly. 
5. Then explode these complete lines into an array $array and proceed with actOnOutput() function.

You will also notice I changed some lines on the tests but this is purely because my computer is slower than yours and I could not test the package even before my change!

Tests before and after my PR, same time, same result.
<img width="403" alt="Capture d’écran 2023-10-29 à 11 17 58" src="https://github.com/spatie/file-system-watcher/assets/1408020/00da4fd9-93cc-4655-b63a-8920c58fd74f">

And, thanks for all your packages guys !
